### PR TITLE
Made possible null fields Nullable

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,8 @@
     "output"
   ],
   "dependencies": {
-    "purescript-aff": "~1.0.0",
-    "purescript-unsafe-coerce": "~1.0.0"
+    "purescript-aff": "^1.0.0",
+    "purescript-unsafe-coerce": "^1.0.0",
+    "purescript-nullable": "^1.0.1"
   }
 }

--- a/src/WebRTC/RTC.js
+++ b/src/WebRTC/RTC.js
@@ -159,8 +159,3 @@ exports.onmessageChannel = function(f) {
     };
 };
 
-exports.newWebSocket = function(url) {
-    return function() {
-        return new WebSocket(url);
-    };
-};

--- a/src/WebRTC/RTC.purs
+++ b/src/WebRTC/RTC.purs
@@ -22,13 +22,13 @@ module WebRTC.RTC (
 , onmessageChannel
 ) where
 
-import Prelude (Unit(), unit)
-import Control.Monad.Aff (Aff(), makeAff)
-import Control.Monad.Eff (Eff())
-import Control.Monad.Eff.Exception (Error())
-import Data.Maybe (Maybe(..))
-
 import WebRTC.MediaStream
+import Control.Monad.Aff (Aff, makeAff)
+import Control.Monad.Eff (Eff)
+import Control.Monad.Eff.Exception (Error)
+import Data.Maybe (Maybe(..))
+import Data.Nullable (Nullable)
+import Prelude (Unit, unit)
 
 foreign import data RTCPeerConnection :: *
 
@@ -42,8 +42,8 @@ foreign import addStream
 
 foreign import data IceEvent :: *
 
-type RTCIceCandidate = { sdpMLineIndex :: Int
-                       , sdpMid :: String
+type RTCIceCandidate = { sdpMLineIndex :: Nullable Int
+                       , sdpMid :: Nullable String
                        , candidate :: String
                        }
 


### PR DESCRIPTION
According to the spec: https://www.w3.org/TR/webrtc/#rtcicecandidate-interface
the fields sdpMLineIndex and sdpMid in the serialized RTCIceCandidate
may be null.

In addition some cleanup and friendlier dependency specs (I think).
